### PR TITLE
Two suggested modifications

### DIFF
--- a/src/CBUSSAM3X8E.cpp
+++ b/src/CBUSSAM3X8E.cpp
@@ -70,8 +70,8 @@ void CBUSSAM3X8E::setControllerInstance(byte instance) {
 //
 /// initialise the CAN controller and buffers, and attach the ISR
 //
-
-bool CBUSSAM3X8E::begin(bool poll, SPIClass spi = SPI) {
+// The default argument is wrong here.
+bool CBUSSAM3X8E::begin(bool poll, SPIClass spi) {
 
   uint32_t init_ret;
   int init_watch;

--- a/src/CBUSSAM3X8E.h
+++ b/src/CBUSSAM3X8E.h
@@ -48,6 +48,10 @@
 
 #include <due_can.h>            // Due CAN library header file
 
+// Defined to deal with the wrong interpretation of the due_can returns.
+// It returns 1 when things are OK. JPF
+#define CAN_MAILBOX_TRANSFER_OK       1     
+
 //
 /// an implementation of the abstract base CBUS class
 /// to support the SAM3X8E CAN controller peripheral


### PR DESCRIPTION
The default argument SPI is wrong in the *.cpp file. The other modification is to take correct on the report from due_can.